### PR TITLE
Reset Inputs on Add Books

### DIFF
--- a/orders/edit.html
+++ b/orders/edit.html
@@ -244,9 +244,7 @@
     // Changes the value of the edit form
     document.getElementById("new_book_order_id").value = order_id;
     
-    //creates the delete button for deleting the order
     
-
 
 
     // Ajax call to get all of a user's books.
@@ -469,6 +467,17 @@
   // Shows the add new book dialog
   function displayAddBookDialog()
   {
+    //clears the input boxes
+    //$("#new_book_modal input[type='text']").value = "";
+
+    $("#new_book_form").trigger('reset');
+
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
+    const order_id = urlParams.get('order_id');
+    document.getElementById("new_book_order_id").value = order_id;
+
+    //Actually does the showing
     $("#new_book_modal").modal("show");
   }
 


### PR DESCRIPTION
New book modal was retaining the previously entered values when adding multiple books in a row. Caused them to reset between additions.